### PR TITLE
List pagination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Changelog
+
+All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
+
+## 1.1.0 (2020-11-20)
+
+
+### Features
+
+* added post_query_hook functionality ([90db8fc](https://github.com/mtShaikh/flask-rest-paginate/commit/90db8fce8d8207d25a99eaa9a1240dd26bee77ff))
+* enabled pagination for one route ([7492152](https://github.com/mtShaikh/flask-rest-paginate/commit/74921520fe068f5b61f7ea174b6084f9a910ef2c))
+
+
+### Bug Fixes
+
+* added DB as the parameter for Pagination ([41bfb71](https://github.com/mtShaikh/flask-rest-paginate/commit/41bfb71bd1c3abcfa230051e691cd36662c2f2f3))
+* fixed dependency typo ([a090a96](https://github.com/mtShaikh/flask-rest-paginate/commit/a090a96eed93400f06b362f7e849c35253e8858e))
+* fixed dependency typo ([6ae01db](https://github.com/mtShaikh/flask-rest-paginate/commit/6ae01db236630c0755ed723e3ddef31db3baacd8))
+* fixed merge conflicts while pulling master ([8d91d59](https://github.com/mtShaikh/flask-rest-paginate/commit/8d91d5987a0f819cc6d7c5af69465196a5e56b12))
+* fixed version name ([efbde23](https://github.com/mtShaikh/flask-rest-paginate/commit/efbde2391be5f45db199db8df236285e258176f8))
+* marshmallow dump issue ([2dde0fe](https://github.com/mtShaikh/flask-rest-paginate/commit/2dde0fee23bee279639ee96d75d6bafe530f65ee))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [1.1.1](https://github.com/mtShaikh/flask-rest-paginate/compare/v1.1.0...v1.1.1) (2021-01-05)
+
+
+### Bug Fixes
+
+* corrected incorrect signature error propagtion ([41c524d](https://github.com/mtShaikh/flask-rest-paginate/commit/41c524d3e6af74cd50f9e6e91f46369972214a80))
+
 ## 1.1.0 (2020-11-20)
 
 

--- a/example/list_pagination_example.py
+++ b/example/list_pagination_example.py
@@ -1,0 +1,75 @@
+import random
+from flask import Flask
+from flask_restful import Api, Resource, marshal_with_field
+from flask_sqlalchemy import SQLAlchemy
+from flask_rest_paginate import Pagination
+from marshmallow import Schema, fields
+
+"""
+Initialize the app
+"""
+app = Flask(__name__)
+api = Api(app)
+
+app.config['SQLALCHEMY_DATABASE_URI'] = "sqlite:///paginate-test.db"
+app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+db = SQLAlchemy(app)
+
+# Possible configurations for Paginate
+# app.config['PAGINATE_PAGE_SIZE'] = 20
+# app.config['PAGINATE_PAGE_PARAM'] = "pagenumber"
+# app.config['PAGINATE_SIZE_PARAM'] = "pagesize"
+# app.config['PAGINATE_RESOURCE_LINKS_ENABLED'] = False
+pagination = Pagination(app, db)
+
+class CalculationSchema(Schema):
+    calculation_time = fields.Str()
+    value = fields.Str()
+
+"""
+Controllers
+"""
+class CalculationList(Resource):
+    def get(self):
+        """
+        Simulates a long running computation that needs to be
+        performed by a backend service.
+        :return:
+        """
+        import time
+
+        def largest_prime_factor(n):
+            """
+            Returns the largest prime factor of a number
+            :param n:
+            :return:
+            """
+            i = 2
+            while i * i <= n:
+                if n % i:
+                    i += 1
+                else:
+                    n //= i
+            return n
+
+        result_list = []
+        for i in range(100):
+            start = time.time()
+            prime = largest_prime_factor(random.randint(100000, 200000))
+            result_list.append({"calculation_time": time.time() - start, "value": prime})
+
+        return pagination.paginate(result_list, CalculationSchema(many=True), marshmallow=True)
+
+"""
+Register the resources
+"""
+api.add_resource(CalculationList, '/calculation')
+
+
+"""
+Run the app
+"""
+if __name__ == '__main__':
+    app.run(debug=True)
+
+

--- a/example/list_pagination_example.py
+++ b/example/list_pagination_example.py
@@ -1,7 +1,6 @@
 import random
 from flask import Flask
-from flask_restful import Api, Resource, marshal_with_field
-from flask_sqlalchemy import SQLAlchemy
+from flask_restful import Api, Resource
 from flask_rest_paginate import Pagination
 from marshmallow import Schema, fields
 
@@ -11,16 +10,12 @@ Initialize the app
 app = Flask(__name__)
 api = Api(app)
 
-app.config['SQLALCHEMY_DATABASE_URI'] = "sqlite:///paginate-test.db"
-app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
-db = SQLAlchemy(app)
-
 # Possible configurations for Paginate
 # app.config['PAGINATE_PAGE_SIZE'] = 20
 # app.config['PAGINATE_PAGE_PARAM'] = "pagenumber"
 # app.config['PAGINATE_SIZE_PARAM'] = "pagesize"
 # app.config['PAGINATE_RESOURCE_LINKS_ENABLED'] = False
-pagination = Pagination(app, db)
+pagination = Pagination(app)
 
 class CalculationSchema(Schema):
     calculation_time = fields.Str()
@@ -42,7 +37,7 @@ class CalculationList(Resource):
             """
             Returns the largest prime factor of a number
             :param n:
-            :return:
+            :return: The largest prime factor of a number
             """
             i = 2
             while i * i <= n:

--- a/example/list_pagination_example.py
+++ b/example/list_pagination_example.py
@@ -27,7 +27,7 @@ Controllers
 class CalculationList(Resource):
     def get(self):
         """
-        Simulates a long running computation that needs to be
+        Simulates a computation that needs to be
         performed by a backend service.
         :return:
         """

--- a/flask_rest_paginate/__init__.py
+++ b/flask_rest_paginate/__init__.py
@@ -115,9 +115,10 @@ class Pagination:
 
         items = page_obj.items
         if post_query_hook:
-            items = post_query_hook(page_obj.items)
-        if not items:
-            raise ValueError("Incorrect signature")
+            try:
+                items = post_query_hook(page_obj.items)
+            except TypeError:
+                raise ValueError("Incorrect signature for hook")
 
         return {
             # TODO: use a better name for the pagination object

--- a/flask_rest_paginate/__init__.py
+++ b/flask_rest_paginate/__init__.py
@@ -1,4 +1,3 @@
-from importlib import util
 from collections import OrderedDict
 from flask import request, url_for
 import flask_restful as f
@@ -61,7 +60,7 @@ class Pagination:
         # TODO: linked to db exception
         # if model is a list
         if isinstance(query_model, list):
-            from flask_rest_paginate.list_pagination import paginate, ListPagination
+            from flask_rest_paginate.list_pagination import paginate
             page_obj = paginate(query_model, page=page_num, per_page=size)
         # elif it is an SQLAlchemy model
         elif isinstance(query_model, type(self._db.Model)):

--- a/flask_rest_paginate/__init__.py
+++ b/flask_rest_paginate/__init__.py
@@ -3,7 +3,6 @@ from collections import OrderedDict
 from flask import request, url_for
 import flask_restful as f
 
-
 class Pagination:
     DEFAULT_PAGE_NUMBER = 1
     _default_page_size = 20
@@ -60,8 +59,12 @@ class Pagination:
             size = self._default_page_size
 
         # TODO: linked to db exception
-        # if Model, run the default query
-        if isinstance(query_model, type(self._db.Model)):
+        # if model is a list
+        if isinstance(query_model, list):
+            from flask_rest_paginate.list_pagination import paginate, ListPagination
+            page_obj = paginate(query_model, page=page_num, per_page=size)
+        # elif it is an SQLAlchemy model
+        elif isinstance(query_model, type(self._db.Model)):
             # `error_out` makes it so that it doesnt throw a 404 when page_num is
             # above total page limit
             page_obj = query_model.query.paginate(page=page_num, per_page=size, error_out=False)

--- a/flask_rest_paginate/list_pagination.py
+++ b/flask_rest_paginate/list_pagination.py
@@ -1,0 +1,50 @@
+class ListPagination:
+    def __init__(self, list_):
+        self.list_ = list_
+
+    @property
+    def next_num(self):
+
+        self.last_page = 1 + self.pages - 1
+        if self.page < self.last_page:
+            return self.page + 1
+        else:
+            return None
+
+    @property
+    def prev_num(self):
+        if self.page > 1:
+            return self.page - 1
+        else:
+            return None
+
+    @property
+    def has_next(self):
+        last = (self.page - 1) * self.per_page + self.per_page
+        return last < len(self.list_)
+
+    @property
+    def has_prev(self):
+        first = (self.page - 1) * self.per_page
+        return first > 0
+
+    @property
+    def pages(self):
+        return ((len(self.list_) - 1) // self.per_page) + 1
+
+    @property
+    def total(self):
+        return len(self.list_)
+
+    def paginate(self, **kwargs):
+        first = (self.page - 1) * self.per_page
+        last = first + self.per_page
+        self.items = self.list_[first:last]
+
+
+def paginate(query_model, **kwargs):
+    type = ListPagination(query_model)
+    type.page = kwargs.get("page")
+    type.per_page = kwargs.get("per_page")
+    type.paginate()
+    return type

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ install_requires = ['flask-sqlalchemy', 'flask-restful']
 
 setup(
     name='flask-rest-paginate',
-    version='0.1.5',
+    version='1.1.0',
     packages=find_packages(),
     url='https://github.com/mtShaikh/flask-rest-paginate',
     license='MIT',

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ install_requires = ['flask-sqlalchemy', 'flask-restful']
 
 setup(
     name='flask-rest-paginate',
-    version='1.1.0',
+    version='1.1.1',
     packages=find_packages(),
     url='https://github.com/mtShaikh/flask-rest-paginate',
     license='MIT',


### PR DESCRIPTION
Pagination is currently only possible using SQLAlchemy.
This PR adds functionality to additionally paginate Python lists. This is useful if the requested data is not stored in a database (e.g. the data comes from a file or the data needs to be calculated). 
The example program simulates such a calculation and shows how the calculated data can be paginated.